### PR TITLE
🪲 [Fix]: Add .codespellrc to skip linter config directory

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.github/linters
+ignore-words-list = afterall


### PR DESCRIPTION
## Context

The [super-linter](https://github.com/super-linter/super-linter) `SPELL_CODESPELL` check flags intentional misspellings in `.github/linters/.textlintrc` (e.g. `environemnt`, `pacakge`). These strings exist as linter configuration patterns and are not actual typos.

The [GitHub](https://github.com/PSModule/GitHub), [GoogleFonts](https://github.com/PSModule/GoogleFonts), and [NerdFonts](https://github.com/PSModule/NerdFonts) repos already solved this by adding a `.codespellrc` file.

## Changes

- Added `.github/linters/.codespellrc` that tells codespell to skip the `.github/linters` directory and ignore the word `afterall`